### PR TITLE
Add lift type selection and update calculations for one-rep max

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ function App() {
   const [weight, setWeight] = useLocalStorage<number | ''>('weight', '');
   const [reps, setReps] = useLocalStorage<number | ''>('reps', '');
   const [unit, setUnit] = useLocalStorage<string>('unit', 'lbs');
+  const [liftType, setLiftType] = useLocalStorage<string>('liftType', 'Squat');
   const [isDarkMode, toggleTheme] = useTheme();
   const [isInfoOpen, setIsInfoOpen] = useState<boolean>(false);
   const calculatorRef = useRef(null);
@@ -34,6 +35,10 @@ function App() {
 
   const handleUnitChange = (newUnit: string) => {
     setUnit(newUnit);
+  };
+
+  const handleLiftTypeChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    setLiftType(e.target.value);
   };
 
   const handleDarkModeToggle = (mode: 'dark' | 'light') => {
@@ -57,9 +62,11 @@ function App() {
           weight={weight}
           reps={reps}
           unit={unit}
+          liftType={liftType}
           onWeightChange={handleWeightChange}
           onRepsChange={handleRepsChange}
           onUnitChange={handleUnitChange}
+          onLiftTypeChange={handleLiftTypeChange}
           isDarkMode={isDarkMode}
         />
         <CSSTransition
@@ -70,7 +77,7 @@ function App() {
           nodeRef={calculatorRef}
         >
           <div ref={calculatorRef}>
-            <CalculatedRepsDisplay weight={Number(weight)} reps={Number(reps)} unit={unit} isDarkMode={isDarkMode} />
+            <CalculatedRepsDisplay weight={Number(weight)} reps={Number(reps)} unit={unit} liftType={liftType} isDarkMode={isDarkMode} />
           </div>
         </CSSTransition>
       </div>

--- a/src/components/CalculatedRepsDisplay.tsx
+++ b/src/components/CalculatedRepsDisplay.tsx
@@ -6,6 +6,7 @@ interface CalculatedRepsDisplayProps {
   weight: number;
   reps: number;
   unit: string;
+  liftType: string;
   isDarkMode: boolean;
 }
 
@@ -27,8 +28,8 @@ function PercentageDisplay({ percentage, oneRepMax, unit, isDarkMode }: Percenta
   );
 }
 
-function CalculatedRepsDisplay({ weight, reps, unit, isDarkMode }: CalculatedRepsDisplayProps) {
-  const oneRepMax = calculateAverageOneRepMax(weight, reps);
+function CalculatedRepsDisplay({ weight, reps, unit, liftType, isDarkMode }: CalculatedRepsDisplayProps) {
+  const oneRepMax = calculateAverageOneRepMax(weight, reps, liftType);
 
   return (
     <div className={`p-4 rounded-lg shadow-md mt-3 ${isDarkMode ? 'bg-dark-secondary text-dark-text' : 'bg-light-secondary text-light-text'}`}>

--- a/src/components/InfoScreen.tsx
+++ b/src/components/InfoScreen.tsx
@@ -25,12 +25,18 @@ function InfoScreen({ isOpen, onClose, isDarkMode }: InfoScreenProps) {
           &times;
         </button>
         <h2 className="text-xl font-bold mb-4">How does this john work?</h2>
-        <p className="w-full mb-4">
+        <p className="w-full mb-2">
           We use a bunch of different
           <a href="https://www.vbtcoach.com/blog/5-ways-to-measure-1rm-strength-in-the-gym" className="mx-1 underline underline-offset-2 hover:text-[#FFD43B] focus:text-[#FFD43B]">formulas</a>
           to gather the average value and provide you with your 1 rep max!
           <br />
         </p>
+        <ul className="list-disc list-inside ml-2 mb-2 text-left">
+          <li><strong>Squat:</strong> Epley formula</li>
+          <li><strong>Bench Press:</strong> Wathan and Mayhew formulas</li>
+          <li><strong>Deadlift:</strong> Brzycki and Epley formulas</li>
+          <li><strong>Other Lifts:</strong> Lombardi and O'Conner formulas</li>
+        </ul>
         <p className="mb-4">
           This provides a solid estimate of your 1 rep max, but it may not be perfectly accurate for everyone. It always give me the confidence of around what my 1RM will be. Only one way to find out for sure, though!
         </p>

--- a/src/components/WeightInputForm.tsx
+++ b/src/components/WeightInputForm.tsx
@@ -5,9 +5,11 @@ interface WeightInputFormProps {
   weight: number | '';
   reps: number | '';
   unit: string;
+  liftType: string;
   onWeightChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onRepsChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onUnitChange: (unit: string) => void;
+  onLiftTypeChange: (e: ChangeEvent<HTMLSelectElement>) => void;
   isDarkMode: boolean;
 }
 
@@ -15,11 +17,14 @@ function WeightInputForm({
   weight,
   reps,
   unit,
+  liftType,
   onWeightChange,
   onRepsChange,
   onUnitChange,
+  onLiftTypeChange,
   isDarkMode,
 }: WeightInputFormProps) {
+
   const handleUnitToggle = () => {
     const newUnit = unit === 'lbs' ? 'kg' : 'lbs';
     onUnitChange(newUnit);
@@ -50,15 +55,30 @@ function WeightInputForm({
             </button>
           </div>
         </div>
-        <div className="mb-4">
-          <label className={`block text-md font-medium ${isDarkMode ? 'text-dark-text' : 'text-light-text'}`}>Reps</label>
-          <input
-            type="number"
-            value={reps}
-            onChange={onRepsChange}
-            max={9999}
-            className={`mt-1 block w-full px-3 py-2 border ${isDarkMode ? 'bg-dark-secondary border-dark-border text-dark-text' : 'bg-light-secondary border-light-border text-light-text'} rounded-md focus:outline-none focus:ring-[#FFD43B] focus:border-[#FFD43B] sm:text-lg hover:border-[#FFD43B]`}
-          />
+        <div className="mb-4 flex">
+          <div className="w-1/2 pr-2">
+            <label className={`block text-md font-medium ${isDarkMode ? 'text-dark-text' : 'text-light-text'}`}>Reps</label>
+            <input
+              type="number"
+              value={reps}
+              onChange={onRepsChange}
+              max={999}
+              className={`mt-1 block w-full px-3 py-2 border ${isDarkMode ? 'bg-dark-secondary border-dark-border text-dark-text' : 'bg-light-secondary border-light-border text-light-text'} rounded-md focus:outline-none focus:ring-[#FFD43B] focus:border-[#FFD43B] sm:text-lg hover:border-[#FFD43B]`}
+            />
+          </div>
+          <div className="w-1/2 pl-2">
+            <label className={`block text-md font-medium ${isDarkMode ? 'text-dark-text' : 'text-light-text'}`}>Lift Type</label>
+            <select
+              value={liftType}
+              onChange={onLiftTypeChange}
+              className={`mt-1 block w-full px-3 py-2 border ${isDarkMode ? 'bg-dark-secondary border-dark-border text-dark-text' : 'bg-light-secondary border-light-border text-light-text'} rounded-md focus:outline-none focus:ring-[#FFD43B] focus:border-[#FFD43B] sm:text-lg hover:border-[#FFD43B]`}
+            >
+              <option value="Squat">Squat</option>
+              <option value="Bench">Bench</option>
+              <option value="Deadlift">Deadlift</option>
+              <option value="Other">Other</option>
+            </select>
+          </div>
         </div>
       </div>
     </div>

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -1,48 +1,60 @@
+// Calculation formulas
 export const calculateBrzycki = (weight: number, reps: number): number => {
-  return Math.round(weight / (1.0278 - 0.0278 * reps));
+  return Math.round(weight * (36 / (37 - reps)));
 };
 
 export const calculateEpley = (weight: number, reps: number): number => {
-  return Math.round(weight * (1 + reps / 30));
-};
-
-export const calculateLander = (weight: number, reps: number): number => {
-  return Math.round((100 * weight) / (101.3 - 2.67123 * reps));
-};
-
-export const calculateLombardi = (weight: number, reps: number): number => {
-  return Math.round(weight * Math.pow(reps, 0.10));
+  return Math.round(weight * (1 + 0.0333 * reps));
 };
 
 export const calculateMayhew = (weight: number, reps: number): number => {
   return Math.round((100 * weight) / (52.2 + 41.9 * Math.exp(-0.055 * reps)));
 };
 
-export const calculateOConner = (weight: number, reps: number): number => {
-  return Math.round(weight * (1 + 0.025 * reps));
-};
-
 export const calculateWathan = (weight: number, reps: number): number => {
   return Math.round((100 * weight) / (48.8 + 53.8 * Math.exp(-0.075 * reps)));
 };
 
-export const calculateAverageOneRepMax = (weight: number, reps: number): number => {
+export const calculateLombardi = (weight: number, reps: number): number => {
+  return Math.round(weight * Math.pow(reps, 0.10));
+};
+
+export const calculateOConner = (weight: number, reps: number): number => {
+  return Math.round(weight * (1 + 0.025 * reps));
+};
+
+// Calculate average one-rep max based on lift type
+export const calculateAverageOneRepMax = (weight: number, reps: number, liftType: string): number => {
   if (reps === 1) {
     return weight;
   }
 
-  const brzycki = calculateBrzycki(weight, reps);
-  const epley = calculateEpley(weight, reps);
-  const lander = calculateLander(weight, reps);
-  const lombardi = calculateLombardi(weight, reps);
-  const mayhew = calculateMayhew(weight, reps);
-  const oConner = calculateOConner(weight, reps);
-  const wathan = calculateWathan(weight, reps);
+  let calculatedMax: number;
 
-  const average = (brzycki + epley + lander + lombardi + mayhew + oConner + wathan) / 7;
-  return Math.round(average);
+  switch (liftType) {
+    case 'Squat':
+      calculatedMax = calculateEpley(weight, reps);
+      break;
+    case 'Bench':
+      calculatedMax = calculateAverage([calculateWathan(weight, reps), calculateMayhew(weight, reps)]);
+      break;
+    case 'Deadlift':
+      calculatedMax = calculateAverage([calculateBrzycki(weight, reps), calculateEpley(weight, reps)]);
+      break;
+    case 'Other':
+    default:
+      calculatedMax = calculateAverage([calculateLombardi(weight, reps), calculateOConner(weight, reps)]);
+      break;
+  }
+
+  return Math.round(calculatedMax);
 };
 
+// Helper function to calculate the average of an array of numbers
+const calculateAverage = (values: number[]): number => 
+  values.reduce((acc, val) => acc + val, 0) / values.length;
+
+// Calculate the number of reps at a given percentage of one-rep max
 export const calculateReps = (oneRepMax: number, percentage: number): number => {
   const weightAtPercentage = oneRepMax * (percentage / 100);
   if (weightAtPercentage === 0) return 0;


### PR DESCRIPTION
Now contains a lift type selector as users believe different lifts have perceived different maxes compared to the average. Updated formulas to match.